### PR TITLE
Remove cinst from script

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,4 +40,4 @@ deploy_script:
 on_finish:
   - ps: Push-AppveyorArtifact $Env:APPVEYOR_BUILD_FOLDER\test.xml
   - ps: Push-AppveyorArtifact C:\ProgramData\chocolatey\logs\chocolatey.log
-  - ps: Get-ChildItem C:\Users\appveyor\.cpanm\work\*\build.log | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
+  - ps: Get-ChildItem C:\Users\appveyor\.cpanm\work\*\build.log | % { Push-AppveyorArtifact $_.FullName -FileName $_.FullName }

--- a/latexml.nuspec
+++ b/latexml.nuspec
@@ -22,8 +22,6 @@
     <description><![CDATA[In the process of developing the Digital Library of Mathematical Functions, NIST had needed a means of transforming the LaTeX sources of our material into XML which would be used for further manipulations, rearrangements and construction of the web site. In particular, a true ‘Digital Library’ should focus on the semantics of the material, and so NIST should convert the mathematical material into both content and presentation MathML. At the time, there found no software suitable to our needs, so NIST began development of LaTeXML in-house.]]></description>
     <dependencies>
       <dependency id="strawberryperl" version="5.28.1.1" />
-      <!-- miktex will be installed manually to make sure that it's belong to right Perl distribution -->
-      <!--dependency id="miktex" version="2.9.6942" /-->
       <dependency id="imagemagick.tool" version="6.8.9.1" />
     </dependencies>
   </metadata>

--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -1,11 +1,10 @@
 $Strawberry = "C:\Strawberry"
-
-# We need to install 'miktex' manually to make sure that it's installed for 'Strawberry Perl'
 $env:Path = "$Strawberry\c\bin;$Strawberry\perl\site\bin;$Strawberry\perl\bin;$Env:Path"
-if (!(Test-Path -Path "$Env:ChocolateyInstall\lib\miktex")) {
-   & cinst -y miktex
-}
 
-& cpanm --verbose LaTeXML@$Env:ChocolateyPackageVersion
+# We need --notest here because:
+# Difference at line 1 for ****
+#       got : 'kpsewhich: warning: running with administrator privileges'
+#  expected : 'No obvious problems'
+& cpanm --notest --verbose LaTeXML@$Env:ChocolateyPackageVersion
 
 Get-Command latexml | Select-Object -ExpandProperty Definition


### PR DESCRIPTION
The package script contains a choco command. This is not allowed. Perhaps there should be a dependency on a package? [More...](https://github.com/chocolatey/package-validator/wiki/ScriptsDoNotContainChocoCommands)